### PR TITLE
Sanity check username, and clean up exception propagation in python > 3.4.  (Also change main invocation to be 'python3' and not 'python3.4')

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Changes by 'TanerH':
 1) in `coordinator.py`, write data to a temp file before overwriting the old file (prevents race conditions)
 2) in `jsonclient.py`, sanity check the username that is sent, disconnecting if invalid (non-alnum)
+3) Clean up exception propagation (dummy loop exception handler added), and clean up the "cleanup" when clients exit.
 
 ## Original README below --
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # mlat-server
 
+# Changes by 'TanerH':
+1) in `coordinator.py`, write data to a temp file before overwriting the old file (prevents race conditions)
+2) in `jsonclient.py`, sanity check the username that is sent, disconnecting if invalid (non-alnum)
+
+## Original README below --
+
 This is a Mode S multilateration server that is designed to operate with
 clients that do _not_ have synchronized clocks.
 

--- a/mlat-server
+++ b/mlat-server
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.4
+#!/usr/bin/env python3
 # -*- mode: python; indent-tabs-mode: nil -*-
 
 # mlat-server: a Mode S multilateration server

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -233,10 +233,7 @@ class JsonClient(connection.Connection):
 
     @asyncio.coroutine
     def wait_closed(self):
-        try:
-            yield from util.safe_wait([self._read_task, self._heartbeat_task])
-        except Exception:
-            pass
+        yield from util.safe_wait([self._read_task, self._heartbeat_task])
 
     @asyncio.coroutine
     def handle_heartbeats(self):

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -276,7 +276,13 @@ class JsonClient(connection.Connection):
 
         try:
             hs = yield from asyncio.wait_for(self.r.readline(), timeout=30.0)
-            if not self.process_handshake(hs):
+            try:
+                ph = self.process_handshake(hs)
+            except Exception:
+                self.logger.exception('Exception in process_handshake')
+                return
+
+            if not ph:
                 return
 
             # start heartbeat handling now that the handshake is done
@@ -315,7 +321,7 @@ class JsonClient(connection.Connection):
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
                 if user_ok is None:
-                    raise ValueError("Bad chars in username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
+                    raise ValueError("Bad username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
 
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -276,13 +276,7 @@ class JsonClient(connection.Connection):
 
         try:
             hs = yield from asyncio.wait_for(self.r.readline(), timeout=30.0)
-            try:
-                ph = self.process_handshake(hs)
-            except Exception:
-                self.logger.exception('Exception in process_handshake')
-                return
-
-            if not ph:
+            if not self.process_handshake(hs):
                 return
 
             # start heartbeat handling now that the handshake is done
@@ -321,7 +315,7 @@ class JsonClient(connection.Connection):
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
                 if user_ok is None:
-                    raise ValueError("Bad username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
+                    raise ValueError("Bad chars in username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
 
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -315,7 +315,7 @@ class JsonClient(connection.Connection):
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
                 # Newlines wreak havoc on log files, strip them
-                safe_user = re.sub("\n|\r", "\\n", user)
+                safe_user = re.sub("\n|\r", "\n", user)
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -314,7 +314,7 @@ class JsonClient(connection.Connection):
                 # Make sure the user string is sane...
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
-		safe_user = re.replace('\n', user)
+                safe_user = re.replace('\n', user)
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -310,10 +310,10 @@ class JsonClient(connection.Connection):
 
                 user = str(hs['user'])
 
-		# Make sure the user string is sane...
-		good_user_regex = '^[A-Za-z0-9_.-]+$'
-		user_ok = re.match(good_user_regex, user)
-		if user_ok is None:
+                # Make sure the user string is sane...
+                good_user_regex = '^[A-Za-z0-9_.-]+$'
+                user_ok = re.match(good_user_regex, user)
+                if user_ok is None:
                     raise ValueError("Bad characters in username.  Please only use alphanumerics, or '_', '-', or '.'")
 
                 peer_compression_methods = set(hs['compress'])

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -233,7 +233,10 @@ class JsonClient(connection.Connection):
 
     @asyncio.coroutine
     def wait_closed(self):
-        yield from util.safe_wait([self._read_task, self._heartbeat_task])
+        try:
+            yield from util.safe_wait([self._read_task, self._heartbeat_task])
+        except Exception:
+            pass
 
     @asyncio.coroutine
     def handle_heartbeats(self):

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -315,7 +315,7 @@ class JsonClient(connection.Connection):
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
                 # Newlines wreak havoc on log files, strip them
-                safe_user = re.sub("\n|\r", "\n", user)
+                safe_user = re.sub("\n|\r", r'\n', user)
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -314,8 +314,9 @@ class JsonClient(connection.Connection):
                 # Make sure the user string is sane...
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
+		safe_user = re.replace('\n', user)
                 if user_ok is None:
-                    raise ValueError("Bad chars in username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
+                    raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -320,11 +320,7 @@ class JsonClient(connection.Connection):
                 # Newlines wreak havoc on log files, strip them
                 safe_user = re.sub("\n|\r", r'\\n', user)
                 if user_ok is None:
-<<<<<<< HEAD
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
-=======
-                    raise ValueError("Bad chars in username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
->>>>>>> parent of 1c71d30... Testing some cleanup
 
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -315,7 +315,7 @@ class JsonClient(connection.Connection):
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
                 # Newlines wreak havoc on log files, strip them
-                safe_user = re.sub("\n|\r", r'\n', user)
+                safe_user = re.sub("\n|\r", r'\\n', user)
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -31,6 +31,7 @@ import socket
 import inspect
 import sys
 import math
+import re
 
 from mlat import constants, geodesy
 from mlat.server import net, util, connection, config

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -314,7 +314,7 @@ class JsonClient(connection.Connection):
                 # Make sure the user string is sane...
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
-                safe_user = re.replace('\n', user)
+                safe_user = user.replace('\n', "_")
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -315,7 +315,7 @@ class JsonClient(connection.Connection):
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
                 if user_ok is None:
-                    raise ValueError("Bad characters in username.  Please only use alphanumerics, or '_', '-', or '.'")
+                    raise ValueError("Bad chars in username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
 
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -310,6 +310,12 @@ class JsonClient(connection.Connection):
 
                 user = str(hs['user'])
 
+		# Make sure the user string is sane...
+		good_user_regex = '^[A-Za-z0-9_.-]+$'
+		user_ok = re.match(good_user_regex, user)
+		if user_ok is None:
+                    raise ValueError("Bad characters in username.  Please only use alphanumerics, or '_', '-', or '.'")
+
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None
                 for c, readmeth, writemeth in self._compression_methods:

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -314,7 +314,7 @@ class JsonClient(connection.Connection):
                 # Make sure the user string is sane...
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
-                safe_user = user.replace('\n', "_")
+                safe_user = "".join(user.split())
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -320,7 +320,11 @@ class JsonClient(connection.Connection):
                 # Newlines wreak havoc on log files, strip them
                 safe_user = re.sub("\n|\r", r'\\n', user)
                 if user_ok is None:
+<<<<<<< HEAD
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
+=======
+                    raise ValueError("Bad chars in username '{user}'.  Please only use alphanumerics, '_', '-', or '.'".format(user=user))
+>>>>>>> parent of 1c71d30... Testing some cleanup
 
                 peer_compression_methods = set(hs['compress'])
                 self.compress = None

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -314,7 +314,8 @@ class JsonClient(connection.Connection):
                 # Make sure the user string is sane...
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
-                safe_user = re.sub("\n|\r| ", "_", user)
+                # Newlines wreak havoc on log files, strip them
+                safe_user = re.sub("\n|\r", "\\n", user)
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/jsonclient.py
+++ b/mlat/server/jsonclient.py
@@ -314,7 +314,7 @@ class JsonClient(connection.Connection):
                 # Make sure the user string is sane...
                 good_user_regex = '^[A-Za-z0-9_.-]+$'
                 user_ok = re.match(good_user_regex, user)
-                safe_user = "".join(user.split())
+                safe_user = re.sub("\n|\r| ", "_", user)
                 if user_ok is None:
                     raise ValueError("Bad username '{user}'.  Please only use alphanum, '_', '-', or '.'".format(user=safe_user))
 

--- a/mlat/server/main.py
+++ b/mlat/server/main.py
@@ -228,6 +228,11 @@ class MlatServer(object):
     def run(self):
         args = self.make_arg_parser().parse_args()
 
+        def loop_handle_exception(loop, context):
+            msg = context.get("exception", context["message"])
+            # Don't really log anything, this is mostly for cleanup for python > 3.4
+            #logging.error(f"Caught exception: {msg}")
+
         self.coordinator = coordinator.Coordinator(work_dir=args.work_dir,
                                                    pseudorange_filename=args.dump_pseudorange,
                                                    partition=args.partition,
@@ -236,6 +241,7 @@ class MlatServer(object):
         subtasks = self.make_subtasks(args)
 
         # Start everything
+        self.loop.set_exception_handler(loop_handle_exception)
         startup = asyncio.gather(*[x.start() for x in subtasks])
         self.loop.run_until_complete(startup)
         startup.result()  # provoke exceptions if something failed

--- a/mlat/server/main.py
+++ b/mlat/server/main.py
@@ -243,7 +243,12 @@ class MlatServer(object):
         self.loop.add_signal_handler(signal.SIGINT, self.stop, "Halting on SIGINT")
         self.loop.add_signal_handler(signal.SIGTERM, self.stop, "Halting on SIGTERM")
 
-        self.loop.run_forever()  # Well, until stop() is called anyway!
+        try:
+            self.loop.run_forever()  # Well, until stop() is called anyway!
+        except Exception:
+            startup.exception()
+        else:
+            startup.exception()
 
         logging.info("Server shutting down.")
 

--- a/mlat/server/main.py
+++ b/mlat/server/main.py
@@ -243,12 +243,7 @@ class MlatServer(object):
         self.loop.add_signal_handler(signal.SIGINT, self.stop, "Halting on SIGINT")
         self.loop.add_signal_handler(signal.SIGTERM, self.stop, "Halting on SIGTERM")
 
-        try:
-            self.loop.run_forever()  # Well, until stop() is called anyway!
-        except Exception:
-            startup.exception()
-        else:
-            startup.exception()
+        self.loop.run_forever()  # Well, until stop() is called anyway!
 
         logging.info("Server shutting down.")
 

--- a/mlat/server/net.py
+++ b/mlat/server/net.py
@@ -86,8 +86,10 @@ class MonitoringListener(object):
     @asyncio.coroutine
     def monitor_client(self, client):
         yield from client.wait_closed()
-        self.clients.remove(client)
-        self.monitoring.remove(asyncio.Task.current_task())
+        if client in self.clients:
+            self.clients.remove(client)
+        if asyncio.Task.current_task() in self.monitoring:
+            self.monitoring.remove(asyncio.Task.current_task())
 
     def close(self):
         if not self.started:


### PR DESCRIPTION
See title ;)

Username has to be alphanumeric also including '_', '-', or '.'
After python 3.4, asyncio and coroutines changes a little, so tried to clean that up - mainly cleaned up exception propagation by adding main loop exception handler.
And changed mlat-server shebang invocation to use 'python3' and not try to explicitly call 'python3.4'.